### PR TITLE
Feature/creatives table and sectors page

### DIFF
--- a/src/app/features/hooks/use.creatives.ts
+++ b/src/app/features/hooks/use.creatives.ts
@@ -1,0 +1,33 @@
+import { useSessionFeature } from "src/app/features/session/session.feature";
+import { useState, useEffect } from "react";
+import { CreativeBackendRepository } from "src/app/features/repositories/catalog/creative.repository";
+import { CreativeLibraryItem } from "src/graphql/client";
+
+export const useCreatives = () => {
+  const { currentBrand }: { currentBrand: any } = useSessionFeature();
+
+  const [creatives, setCreatives] = useState<CreativeLibraryItem[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!currentBrand) return;
+
+    setLoading(true);
+    const repository = new CreativeBackendRepository();
+
+    repository
+      .getCreativesForBrand(currentBrand.id)
+      .then((creatives: CreativeLibraryItem[]) => {
+        setCreatives(creatives);
+      })
+      .catch((err: Error) => {
+        setError(err);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [currentBrand]);
+
+  return { creatives, loading, error };
+};

--- a/src/app/features/repositories/catalog/creative.repository.ts
+++ b/src/app/features/repositories/catalog/creative.repository.ts
@@ -3,7 +3,7 @@ import { CreativeLibraryItem } from "src/graphql/client";
 import { CreativeRepository } from "src/domain/creatives/creatives.domain";
 
 export class CreativeBackendRepository implements CreativeRepository {
-  getCreativesForFolder(brandId: string): Promise<CreativeLibraryItem[]> {
+  getCreativesForFolder(_brandId: string): Promise<CreativeLibraryItem[]> {
     throw new Error("Method not implemented.");
   }
   async getCreativesForBrand(brandId: string): Promise<CreativeLibraryItem[]> {
@@ -30,6 +30,4 @@ export class CreativeBackendRepository implements CreativeRepository {
         });
     });
   }
-
-  // You can add more methods as needed for other queries or mutations
 }

--- a/src/app/features/repositories/catalog/creative.repository.ts
+++ b/src/app/features/repositories/catalog/creative.repository.ts
@@ -1,0 +1,35 @@
+import { client } from "../clients/graphql.client";
+import { CreativeLibraryItem } from "src/graphql/client";
+import { CreativeRepository } from "src/domain/creatives/creatives.domain";
+
+export class CreativeBackendRepository implements CreativeRepository {
+  getCreativesForFolder(brandId: string): Promise<CreativeLibraryItem[]> {
+    throw new Error("Method not implemented.");
+  }
+  async getCreativesForBrand(brandId: string): Promise<CreativeLibraryItem[]> {
+    return new Promise((resolve, reject) => {
+      client.chain.query
+        .listFolder({ input: { brandId: brandId } })
+        .get({
+          creatives: {
+            creativeId: 1,
+            name: 1,
+            fileType: 1,
+            url: 1,
+            status: 1,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        })
+        .then((res) => {
+          if (!res?.creatives) return resolve([]);
+          return resolve(res.creatives as CreativeLibraryItem[]);
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    });
+  }
+
+  // You can add more methods as needed for other queries or mutations
+}

--- a/src/app/mocks/sectors.mock.ts
+++ b/src/app/mocks/sectors.mock.ts
@@ -1,0 +1,77 @@
+interface Sector {
+  id: number;
+  name: string;
+}
+
+interface SectorCount {
+  id: number;
+  count: number;
+}
+
+const sectorsNames: Sector[] = [
+  { id: 1, name: "Apparel and Accessories" },
+  { id: 2, name: "Beauty and Personal Care" },
+  { id: 3, name: "Food and Beverage" },
+  { id: 4, name: "Home and Garden" },
+  { id: 5, name: "Sports and Fitness" },
+  { id: 6, name: "Home Appliances" },
+  { id: 7, name: "Home Improvement" },
+  { id: 8, name: "Household Supplies" },
+  { id: 9, name: "Pet Care" },
+  { id: 10, name: "Tobacco and Smoking Accessories" },
+  { id: 11, name: "Toys and Games" },
+  { id: 12, name: "Oil and Gas" },
+  { id: 13, name: "Renewable Energy" },
+  { id: 14, name: "Utilities" },
+  { id: 15, name: "Banking and Lending" },
+  { id: 16, name: "Insurance" },
+  { id: 17, name: "Investment and Wealth Management" },
+  { id: 18, name: "Pharmaceuticals and Biotechnology" },
+  { id: 19, name: "Medical Devices" },
+  { id: 20, name: "Healthcare Services" },
+  { id: 21, name: "Construction and Engineering" },
+  { id: 22, name: "Aerospace and Defense" },
+  { id: 23, name: "Transportation Equipment" },
+  { id: 24, name: "Software and IT Services" },
+  { id: 25, name: "Hardware and Electronics" },
+  { id: 26, name: "Internet Services" },
+  { id: 27, name: "Telecommunications Equipment" },
+  { id: 28, name: "Telecommunications Services" },
+  { id: 29, name: "Networking Equipment" },
+  { id: 30, name: "Airlines and air transportation" },
+];
+
+const sectorsCounts: SectorCount[] = [
+  { id: 1, count: 457 },
+  { id: 2, count: 512 },
+  { id: 3, count: 79 },
+  { id: 4, count: 687 },
+  { id: 5, count: 234 },
+  { id: 6, count: 820 },
+  { id: 7, count: 112 },
+  { id: 8, count: 400 },
+  { id: 9, count: 517 },
+  { id: 10, count: 300 },
+  { id: 11, count: 700 },
+  { id: 12, count: 120 },
+  { id: 13, count: 350 },
+  { id: 14, count: 600 },
+  { id: 15, count: 450 },
+  { id: 16, count: 250 },
+  { id: 17, count: 500 },
+  { id: 18, count: 100 },
+  { id: 19, count: 550 },
+  { id: 20, count: 200 },
+  { id: 21, count: 650 },
+  { id: 22, count: 150 },
+  { id: 23, count: 700 },
+  { id: 24, count: 50 },
+  { id: 25, count: 750 },
+  { id: 26, count: 400 },
+  { id: 27, count: 800 },
+  { id: 28, count: 350 },
+  { id: 29, count: 750 },
+  { id: 30, count: 300 },
+];
+
+export { sectorsNames, sectorsCounts };

--- a/src/app/pages/creative-intelligence-suite/pages/business-settings/business-settings.routes.ts
+++ b/src/app/pages/creative-intelligence-suite/pages/business-settings/business-settings.routes.ts
@@ -1,3 +1,4 @@
+// business-settings.routes.ts
 import { lazy } from "react";
 import { Route } from "src/app/features/navigation/models/route.model";
 
@@ -8,10 +9,22 @@ const AccountAndBrands = lazy(
     ),
 );
 
+const Sectors = lazy(
+  () =>
+    import(
+      "src/app/pages/creative-intelligence-suite/pages/sectors/sectors.page"
+    ),
+);
+
 export const BusinessSettingsRoutes: Route[] = [
   {
     path: "/business-settings/account-and-brands",
     element: AccountAndBrands,
     title: "Account & Brands",
+  },
+  {
+    path: "/business-settings/sectors",
+    element: Sectors,
+    title: "Sectors",
   },
 ];

--- a/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/creative-library/creative-library.page.tsx
+++ b/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/creative-library/creative-library.page.tsx
@@ -1,8 +1,30 @@
 import { FC } from "react";
 import CardPageUI from "src/app/ui/cards/card-page.ui";
 import { SearchInputUI } from "src/app/ui/inputs/search-input.ui";
+import { useCreatives } from "src/app/features/hooks/use.creatives";
+import { CreativesTableWidget } from "./creatives.table.widget";
+import { LoadingPage } from "src/app/features/operations/features/loadings/pages/loading.page";
 
 const CreativeLibraryPage: FC = () => {
+  const { creatives, loading, error } = useCreatives();
+
+  if (loading) {
+    return (
+      <CardPageUI>
+        <LoadingPage />
+      </CardPageUI>
+    );
+  }
+
+  if (error) {
+    return (
+      <CardPageUI>
+        {/* Replace with your actual error display component */}
+        <div>Error: {error.message}</div>
+      </CardPageUI>
+    );
+  }
+
   return (
     <CardPageUI>
       <header
@@ -17,8 +39,9 @@ const CreativeLibraryPage: FC = () => {
       >
         <SearchInputUI />
       </header>
-      <pre>Insert Table here</pre>
+      <CreativesTableWidget data={creatives} />
     </CardPageUI>
   );
 };
+
 export default CreativeLibraryPage;

--- a/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/creative-library/creative-library.page.tsx
+++ b/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/creative-library/creative-library.page.tsx
@@ -19,7 +19,7 @@ const CreativeLibraryPage: FC = () => {
   if (error) {
     return (
       <CardPageUI>
-        {/* Replace with your actual error display component */}
+        {/* Replace with your actual error display component - maybe add error handling for this in the future? */}
         <div>Error: {error.message}</div>
       </CardPageUI>
     );

--- a/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/creative-library/creatives.table.widget.tsx
+++ b/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/creative-library/creatives.table.widget.tsx
@@ -1,0 +1,47 @@
+import { Avatar, Table } from "antd";
+import { FC } from "react";
+
+interface Creative {
+  creativeId: string;
+  name: string;
+  fileType: string;
+  url: string;
+  createdAt: Date;
+}
+
+interface CreativesTableProps {
+  data: Creative[];
+}
+
+export const CreativesTableWidget: FC<CreativesTableProps> = ({ data }) => {
+  const columns = [
+    {
+      title: "Name",
+      dataIndex: "name",
+      render: (text: string, record: Creative) => (
+        <div style={{ display: "flex", alignItems: "center" }}>
+          <Avatar src={record.url} style={{ marginRight: "8px" }} />
+          {text}
+        </div>
+      ),
+    },
+    {
+      title: "Upload Date",
+      dataIndex: "createdAt",
+      render: (date: any) => {
+        if (!date) return "N/A"; // handle null or undefined date values
+
+        const parsedDate = new Date(date);
+        if (isNaN(parsedDate.getTime())) return "Invalid Date"; // handle invalid date values
+
+        return new Intl.DateTimeFormat().format(parsedDate);
+      },
+    },
+    {
+      title: "File Type",
+      dataIndex: "fileType",
+    },
+  ];
+
+  return <Table columns={columns} dataSource={data} rowKey="creativeId" />;
+};

--- a/src/app/pages/creative-intelligence-suite/pages/sectors/sectors.page.tsx
+++ b/src/app/pages/creative-intelligence-suite/pages/sectors/sectors.page.tsx
@@ -1,0 +1,35 @@
+// sectors.page.tsx
+import { FC, useState, useEffect } from "react";
+import { LoadingPage } from "src/app/features/operations/features/loadings/pages/loading.page";
+import SectorCard from "src/app/ui/cards/sector-card.ui";
+import { sectorsNames, sectorsCounts } from "src/app/mocks/sectors.mock";
+
+const SectorsPage: FC = () => {
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // Simulate a network request with a timeout
+    setTimeout(() => {
+      setLoading(false);
+    }, 1500); // This sets the spinner to run for 1.5 seconds. Adjust as needed.
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <LoadingPage />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-7">
+      {sectorsNames.map((sector) => {
+        const count = sectorsCounts.find((s) => s.id === sector.id)?.count || 0;
+        return <SectorCard key={sector.id} name={sector.name} count={count} />;
+      })}
+    </div>
+  );
+};
+
+export default SectorsPage;

--- a/src/app/pages/creative-intelligence-suite/pages/sectors/sectors.page.tsx
+++ b/src/app/pages/creative-intelligence-suite/pages/sectors/sectors.page.tsx
@@ -23,7 +23,7 @@ const SectorsPage: FC = () => {
   }
 
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-7">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-5 2xl:grid-cols-7">
       {sectorsNames.map((sector) => {
         const count = sectorsCounts.find((s) => s.id === sector.id)?.count || 0;
         return <SectorCard key={sector.id} name={sector.name} count={count} />;

--- a/src/app/ui/cards/sector-card.ui.tsx
+++ b/src/app/ui/cards/sector-card.ui.tsx
@@ -1,0 +1,22 @@
+// SectorCard.tsx
+import { FC } from "react";
+
+interface SectorCardProps {
+  name: string;
+  count: number;
+}
+
+const SectorCard: FC<SectorCardProps> = ({ name, count }) => {
+  return (
+    <div className="my-4 mx-6 h-36 w-36 px-1 md:my-2 md:mx-4">
+      <div className="flex h-full flex-col items-center justify-center bg-gray-200 p-4">
+        <h2 className="mb-4 w-full break-words px-2 text-center text-sm font-bold">
+          {name}
+        </h2>
+        <p className="text-center">{count}</p>
+      </div>
+    </div>
+  );
+};
+
+export default SectorCard;

--- a/src/domain/creatives/creatives.domain.ts
+++ b/src/domain/creatives/creatives.domain.ts
@@ -1,0 +1,22 @@
+import { useRepositoryFeature } from "src/app/features/repositories/repositories.feature";
+import { CreativeLibraryItem } from "src/graphql/client";
+
+export interface CreativeRepository {
+  getCreativesForFolder(brandId: string): Promise<CreativeLibraryItem[]>;
+  // Add other methods if required in the future
+}
+
+export const useCreativesDomain = (repoId = "CreativeRepository") => {
+  const { repository } = useRepositoryFeature<CreativeRepository>(repoId);
+
+  const getCreativesForFolder = (brandId: string) => {
+    return repository.getCreativesForFolder(brandId);
+  };
+
+  // You can add other methods here if needed in the future
+
+  return {
+    getCreativesForFolder,
+    // Include other methods here if you added any
+  };
+};


### PR DESCRIPTION
New hook to retrieve creatives
New domains and repository to handle creatives entity
Updates in the creatives page and a new widget (table) component based on the brands entity

New sectors page
sector card ui to handle sectors name and counter
routing for sectors page created

![888888](https://github.com/tekal-ai/memorable-frontend-test/assets/17914383/12a66268-9935-4214-a236-3ceabd761eca)
![99999999](https://github.com/tekal-ai/memorable-frontend-test/assets/17914383/9daa1919-e55b-49c6-9486-a6e98ed8eb08)


