### PR TITLE
Add “Creatives” table in Library page + Add a new “Sectors” page

### DIFF
--- a/src/app/features/creatives/creatives.feature.ts
+++ b/src/app/features/creatives/creatives.feature.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { useRepositoryFeature } from "src/app/features/repositories/repositories.feature";
+import { CreativesRepository } from "src/domain/creatives/creatives.domain";
+import {
+  CreativeLibraryFilter,
+  CreativeLibraryFolderRequest,
+} from "src/graphql/client";
+import { useSessionFeature } from "../session/session.feature";
+
+export const useCreativesFeature = (repoId = "CreativesRepository") => {
+  const { repository } = useRepositoryFeature<CreativesRepository>(repoId);
+
+  const listFolder = async (args: CreativeLibraryFilter) => {
+    return repository.listFolder(args);
+  };
+
+  return {
+    listFolder,
+  };
+};
+
+export const useCurrentBrandCreatives = () => {
+  const [data, setData] = useState<CreativeLibraryFolderRequest>();
+  const [loading, setLoading] = useState(true);
+
+  const { currentBrand } = useSessionFeature();
+  const { listFolder } = useCreativesFeature();
+
+  useEffect(() => {
+    listFolder({
+      brandId: currentBrand?.id || "",
+    })
+      .then((data) => {
+        setData(data);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, []);
+
+  return {
+    data,
+    loading,
+  };
+};

--- a/src/app/features/creatives/creatives.feature.ts
+++ b/src/app/features/creatives/creatives.feature.ts
@@ -3,7 +3,7 @@ import { useRepositoryFeature } from "src/app/features/repositories/repositories
 import { CreativesRepository } from "src/domain/creatives/creatives.domain";
 import {
   CreativeLibraryFilter,
-  CreativeLibraryFolderRequest,
+  CreativeLibraryFolder,
 } from "src/graphql/client";
 import { useSessionFeature } from "../session/session.feature";
 
@@ -20,7 +20,7 @@ export const useCreativesFeature = (repoId = "CreativesRepository") => {
 };
 
 export const useCurrentBrandCreatives = () => {
-  const [data, setData] = useState<CreativeLibraryFolderRequest>();
+  const [data, setData] = useState<CreativeLibraryFolder>();
   const [loading, setLoading] = useState(true);
 
   const { currentBrand } = useSessionFeature();
@@ -36,7 +36,7 @@ export const useCurrentBrandCreatives = () => {
       .finally(() => {
         setLoading(false);
       });
-  }, []);
+  }, [currentBrand]);
 
   return {
     data,

--- a/src/app/features/repositories/catalog/creatives.repository.ts
+++ b/src/app/features/repositories/catalog/creatives.repository.ts
@@ -1,0 +1,32 @@
+import { CreativesRepository } from "src/domain/creatives/creatives.domain";
+import {
+  CreativeLibraryFilter,
+  CreativeLibraryFolderRequest,
+} from "src/graphql/client";
+import { client } from "../clients/graphql.client";
+
+export class CreativesBackendRepository implements CreativesRepository {
+  async listFolder(
+    args: CreativeLibraryFilter,
+  ): Promise<CreativeLibraryFolderRequest> {
+    return new Promise((resolve) => {
+      client.chain.query
+        .listFolder({
+          input: args,
+        })
+        .get({
+          id: 1,
+          creatives: {
+            creativeId: 1,
+            name: 1,
+            fileType: 1,
+            url: 1,
+            createdAt: 1,
+          },
+        })
+        .then((res) => {
+          return resolve(res as CreativeLibraryFolderRequest);
+        });
+    });
+  }
+}

--- a/src/app/features/repositories/catalog/creatives.repository.ts
+++ b/src/app/features/repositories/catalog/creatives.repository.ts
@@ -1,31 +1,30 @@
 import { CreativesRepository } from "src/domain/creatives/creatives.domain";
 import {
   CreativeLibraryFilter,
-  CreativeLibraryFolderRequest,
+  CreativeLibraryFolder,
 } from "src/graphql/client";
 import { client } from "../clients/graphql.client";
 
 export class CreativesBackendRepository implements CreativesRepository {
   async listFolder(
     args: CreativeLibraryFilter,
-  ): Promise<CreativeLibraryFolderRequest> {
+  ): Promise<CreativeLibraryFolder> {
     return new Promise((resolve) => {
       client.chain.query
         .listFolder({
           input: args,
         })
         .get({
-          id: 1,
           creatives: {
             creativeId: 1,
-            name: 1,
             fileType: 1,
+            name: 1,
+            updatedAt: 1,
             url: 1,
-            createdAt: 1,
           },
         })
         .then((res) => {
-          return resolve(res as CreativeLibraryFolderRequest);
+          return resolve(res as CreativeLibraryFolder);
         });
     });
   }

--- a/src/app/features/repositories/catalog/index.ts
+++ b/src/app/features/repositories/catalog/index.ts
@@ -3,10 +3,12 @@ import { UsersBackendRepository } from "./users.repository";
 import { AssetsBackendRepository } from "./assets.repository";
 import { BusinessBackendRepository } from "./business.repository";
 import { EarlyAccessBackendRepository } from "./early-access.repository";
+import { CreativesBackendRepository } from "./creatives.repository";
 
 export const repository = new Map();
 
 repository.set("BrandRepository", BrandBackendRepository);
+repository.set("CreativesRepository", CreativesBackendRepository);
 repository.set("UsersRepository", UsersBackendRepository);
 repository.set("AssetsRepository", AssetsBackendRepository);
 repository.set("EarlyAccessRepository", EarlyAccessBackendRepository);

--- a/src/app/features/repositories/catalog/index.ts
+++ b/src/app/features/repositories/catalog/index.ts
@@ -4,11 +4,13 @@ import { AssetsBackendRepository } from "./assets.repository";
 import { BusinessBackendRepository } from "./business.repository";
 import { EarlyAccessBackendRepository } from "./early-access.repository";
 import { CreativesBackendRepository } from "./creatives.repository";
+import { SectorsBackendRepository } from "./sectors.repository";
 
 export const repository = new Map();
 
 repository.set("BrandRepository", BrandBackendRepository);
 repository.set("CreativesRepository", CreativesBackendRepository);
+repository.set("SectorsRepository", SectorsBackendRepository);
 repository.set("UsersRepository", UsersBackendRepository);
 repository.set("AssetsRepository", AssetsBackendRepository);
 repository.set("EarlyAccessRepository", EarlyAccessBackendRepository);

--- a/src/app/features/repositories/catalog/sectors.repository.ts
+++ b/src/app/features/repositories/catalog/sectors.repository.ts
@@ -1,0 +1,80 @@
+import { SectorsRepository } from "src/domain/sectors/sectors.domain";
+import {
+  SectorCountRequest,
+  SectorNameRequest,
+} from "src/domain/sectors/sectors.interfaces";
+
+const SECTORS_NAME_MOCK = [
+  { id: 1, name: "Apparel and Accessories" },
+  { id: 2, name: "Beauty and Personal Care" },
+  { id: 3, name: "Food and Beverage" },
+  { id: 4, name: "Home and Garden" },
+  { id: 5, name: "Sports and Fitness" },
+  { id: 6, name: "Home Appliances" },
+  { id: 7, name: "Home Improvement" },
+  { id: 8, name: "Household Supplies" },
+  { id: 9, name: "Pet Care" },
+  { id: 10, name: "Tobacco and Smoking Accessories" },
+  { id: 11, name: "Toys and Games" },
+  { id: 12, name: "Oil and Gas" },
+  { id: 13, name: "Renewable Energy" },
+  { id: 14, name: "Utilities" },
+  { id: 15, name: "Banking and Lending" },
+  { id: 16, name: "Insurance" },
+  { id: 17, name: "Investment and Wealth Management" },
+  { id: 18, name: "Pharmaceuticals and Biotechnology" },
+  { id: 19, name: "Medical Devices" },
+  { id: 20, name: "Healthcare Services" },
+  { id: 21, name: "Construction and Engineering" },
+  { id: 22, name: "Aerospace and Defense" },
+  { id: 23, name: "Transportation Equipment" },
+  { id: 24, name: "Software and IT Services" },
+  { id: 25, name: "Hardware and Electronics" },
+  { id: 26, name: "Internet Services" },
+  { id: 27, name: "Telecommunications Equipment" },
+  { id: 28, name: "Telecommunications Services" },
+  { id: 29, name: "Networking Equipment" },
+  { id: 30, name: "Airlines and air transportation" },
+];
+
+const SECTORS_COUNT_MOCK = [
+  { id: 1, count: 457 },
+  { id: 2, count: 512 },
+  { id: 3, count: 79 },
+  { id: 4, count: 687 },
+  { id: 5, count: 234 },
+  { id: 6, count: 820 },
+  { id: 7, count: 112 },
+  { id: 8, count: 400 },
+  { id: 9, count: 517 },
+  { id: 10, count: 300 },
+  { id: 11, count: 700 },
+  { id: 12, count: 120 },
+  { id: 13, count: 350 },
+  { id: 14, count: 600 },
+  { id: 15, count: 450 },
+  { id: 16, count: 250 },
+  { id: 17, count: 500 },
+  { id: 18, count: 100 },
+  { id: 19, count: 550 },
+  { id: 20, count: 200 },
+  { id: 21, count: 650 },
+  { id: 22, count: 150 },
+  { id: 23, count: 700 },
+  { id: 24, count: 50 },
+  { id: 25, count: 750 },
+  { id: 26, count: 400 },
+  { id: 27, count: 800 },
+  { id: 28, count: 350 },
+  { id: 29, count: 750 },
+  { id: 30, count: 300 },
+];
+
+export class SectorsBackendRepository implements SectorsRepository {
+  async getSectorsName(): Promise<SectorNameRequest[]> {
+    return SECTORS_NAME_MOCK;
+  }
+  async getSectorsCount(): Promise<SectorCountRequest[]> {
+    return SECTORS_COUNT_MOCK;
+  }
+}

--- a/src/app/features/sectors/sectors.feature.ts
+++ b/src/app/features/sectors/sectors.feature.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import { useRepositoryFeature } from "src/app/features/repositories/repositories.feature";
+import { SectorsRepository } from "src/domain/sectors/sectors.domain";
+import { SectorRequest } from "src/domain/sectors/sectors.interfaces";
+
+export const useSectorsFeature = (repoId = "SectorsRepository") => {
+  const { repository } = useRepositoryFeature<SectorsRepository>(repoId);
+
+  const getSectorNames = async () => {
+    return repository.getSectorsName();
+  };
+
+  const getSectorsCount = async () => {
+    return repository.getSectorsCount();
+  };
+
+  return {
+    getSectorNames,
+    getSectorsCount,
+  };
+};
+
+export const useSectors = () => {
+  const [data, setData] = useState<SectorRequest[]>();
+  const [loading, setLoading] = useState(true);
+
+  const { getSectorNames, getSectorsCount } = useSectorsFeature();
+
+  const processSectors = async () => {
+    const [sectorsName, sectorsCount] = await Promise.all([
+      getSectorNames(),
+      getSectorsCount(),
+    ]);
+
+    return (
+      sectorsName.map((sectorName) => {
+        const sectorCount = sectorsCount.find(
+          (count) => count.id === sectorName.id,
+        );
+
+        return {
+          ...sectorName,
+          ...sectorCount,
+        };
+      }) || []
+    );
+  };
+
+  useEffect(() => {
+    processSectors()
+      .then((data) => setData(data))
+      .finally(() => setTimeout(() => setLoading(false), 2000));
+  }, []);
+
+  return {
+    data,
+    loading,
+  };
+};

--- a/src/app/pages/creative-intelligence-suite/pages/business-settings/business-settings.routes.ts
+++ b/src/app/pages/creative-intelligence-suite/pages/business-settings/business-settings.routes.ts
@@ -8,10 +8,22 @@ const AccountAndBrands = lazy(
     ),
 );
 
+const Sectors = lazy(
+  () =>
+    import(
+      "src/app/pages/creative-intelligence-suite/pages/business-settings/pages/sectors/sectors.page"
+    ),
+);
+
 export const BusinessSettingsRoutes: Route[] = [
   {
     path: "/business-settings/account-and-brands",
     element: AccountAndBrands,
     title: "Account & Brands",
+  },
+  {
+    path: "/business-settings/sectors",
+    element: Sectors,
+    title: "Sectors",
   },
 ];

--- a/src/app/pages/creative-intelligence-suite/pages/business-settings/pages/sectors/sectors.page.tsx
+++ b/src/app/pages/creative-intelligence-suite/pages/business-settings/pages/sectors/sectors.page.tsx
@@ -1,0 +1,62 @@
+import { Typography, Row, Col, Grid } from "antd";
+import { FC, useMemo } from "react";
+import { SpinnerUI } from "src/app/features/operations/ui/spinner.ui";
+import { useSectors } from "src/app/features/sectors/sectors.feature";
+import CardPageUI from "src/app/ui/cards/card-page.ui";
+import SectorUI from "src/app/ui/sector/sector.ui";
+
+const { useBreakpoint } = Grid;
+
+const SectorsPage: FC = () => {
+  const viewport = useBreakpoint();
+
+  const getColSpan = () => {
+    if (viewport.md) {
+      return 6;
+    } else if (viewport.sm) {
+      return 12;
+    } else if (viewport.xs) {
+      return 24;
+    } else {
+      return 4;
+    }
+  };
+
+  const span = useMemo(() => getColSpan(), [viewport]);
+
+  const { data, loading } = useSectors();
+
+  return (
+    <CardPageUI>
+      <Typography.Title level={2}>Sectors</Typography.Title>
+      {!loading && (
+        <Row
+          gutter={[
+            { xs: 8, sm: 16, md: 24, lg: 32 },
+            { xs: 8, sm: 16, md: 24, lg: 32 },
+          ]}
+        >
+          {data?.map((item) => (
+            <Col className="gutter-row" span={span} key={item.id}>
+              <SectorUI sectorCount={item.count || 0} sectorName={item.name} />
+            </Col>
+          ))}
+        </Row>
+      )}
+      {loading && (
+        <div
+          style={{
+            width: "100%",
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            height: "100px",
+          }}
+        >
+          <SpinnerUI />
+        </div>
+      )}
+    </CardPageUI>
+  );
+};
+export default SectorsPage;

--- a/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/creative-library/creative-library.page.tsx
+++ b/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/creative-library/creative-library.page.tsx
@@ -1,11 +1,69 @@
-import { FC } from "react";
+import { FC, useMemo } from "react";
 import { useCurrentBrandCreatives } from "src/app/features/creatives/creatives.feature";
 import CardPageUI from "src/app/ui/cards/card-page.ui";
+import { ImageUI } from "src/app/ui/images/image.ui";
 import { SearchInputUI } from "src/app/ui/inputs/search-input.ui";
 import { TableUI } from "src/app/ui/tables/table.ui";
+import { CreativeLibraryItem } from "src/graphql/client";
+import { format } from "date-fns";
 
 const CreativeLibraryPage: FC = () => {
-  useCurrentBrandCreatives();
+  const { data: creativesData } = useCurrentBrandCreatives();
+
+  const columns = useMemo(
+    () => [
+      {
+        title: "Name",
+        dataIndex: "name",
+        key: "name",
+        render: (name: string, creative: CreativeLibraryItem) => {
+          return (
+            <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+              <ImageUI src={creative.url} style={{ height: "1.5rem" }} />
+              {name}
+            </div>
+          );
+        },
+      },
+      {
+        title: "Uploaded Date",
+        dataIndex: "date",
+        key: "date",
+        render: (date) => {
+          return <p>{format(new Date(date), "MM/dd/yyyy")}</p>;
+        },
+      },
+      {
+        title: "File Type",
+        dataIndex: "type",
+        key: "type",
+        render: (type) => {
+          return (
+            <p
+              style={{
+                textTransform: "capitalize",
+              }}
+            >
+              {type.toLowerCase()}
+            </p>
+          );
+        },
+      },
+    ],
+    [],
+  );
+
+  const data = useMemo(
+    () =>
+      creativesData?.creatives?.map((item, index) => ({
+        key: index,
+        name: item.name,
+        date: item.updatedAt,
+        type: item.fileType,
+        url: item.url,
+      })) || [],
+    [creativesData],
+  );
 
   return (
     <CardPageUI>
@@ -21,7 +79,7 @@ const CreativeLibraryPage: FC = () => {
       >
         <SearchInputUI />
       </header>
-      <TableUI columns={[]} data={[]} />
+      <TableUI columns={columns} data={data} />
     </CardPageUI>
   );
 };

--- a/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/creative-library/creative-library.page.tsx
+++ b/src/app/pages/creative-intelligence-suite/pages/creative-lab/pages/creative-library/creative-library.page.tsx
@@ -1,8 +1,12 @@
 import { FC } from "react";
+import { useCurrentBrandCreatives } from "src/app/features/creatives/creatives.feature";
 import CardPageUI from "src/app/ui/cards/card-page.ui";
 import { SearchInputUI } from "src/app/ui/inputs/search-input.ui";
+import { TableUI } from "src/app/ui/tables/table.ui";
 
 const CreativeLibraryPage: FC = () => {
+  useCurrentBrandCreatives();
+
   return (
     <CardPageUI>
       <header
@@ -17,7 +21,7 @@ const CreativeLibraryPage: FC = () => {
       >
         <SearchInputUI />
       </header>
-      <pre>Insert Table here</pre>
+      <TableUI columns={[]} data={[]} />
     </CardPageUI>
   );
 };

--- a/src/app/ui/sector/sector.ui.tsx
+++ b/src/app/ui/sector/sector.ui.tsx
@@ -1,0 +1,30 @@
+import { Typography } from "antd";
+import { FC } from "react";
+
+type SectorProps = {
+  sectorName: string;
+  sectorCount: number;
+  className?: string;
+};
+
+const SectorUI: FC<SectorProps> = ({ sectorName, sectorCount, className }) => {
+  return (
+    <div
+      className={className}
+      style={{
+        background: "#eee",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        height: "150px",
+        textAlign: "center",
+        padding: "25px",
+      }}
+    >
+      <Typography.Title level={5}>{sectorName}</Typography.Title>
+      <Typography.Paragraph>{sectorCount}</Typography.Paragraph>
+    </div>
+  );
+};
+export default SectorUI;

--- a/src/domain/creatives/creatives.domain.ts
+++ b/src/domain/creatives/creatives.domain.ts
@@ -1,10 +1,8 @@
 import {
   CreativeLibraryFilter,
-  CreativeLibraryFolderRequest,
+  CreativeLibraryFolder,
 } from "src/graphql/client";
 
 export interface CreativesRepository {
-  listFolder(
-    args: CreativeLibraryFilter,
-  ): Promise<CreativeLibraryFolderRequest>;
+  listFolder(args: CreativeLibraryFilter): Promise<CreativeLibraryFolder>;
 }

--- a/src/domain/creatives/creatives.domain.ts
+++ b/src/domain/creatives/creatives.domain.ts
@@ -1,0 +1,10 @@
+import {
+  CreativeLibraryFilter,
+  CreativeLibraryFolderRequest,
+} from "src/graphql/client";
+
+export interface CreativesRepository {
+  listFolder(
+    args: CreativeLibraryFilter,
+  ): Promise<CreativeLibraryFolderRequest>;
+}

--- a/src/domain/sectors/sectors.domain.ts
+++ b/src/domain/sectors/sectors.domain.ts
@@ -1,0 +1,6 @@
+import { SectorCountRequest, SectorNameRequest } from "./sectors.interfaces";
+
+export interface SectorsRepository {
+  getSectorsName(): Promise<SectorNameRequest[]>;
+  getSectorsCount(): Promise<SectorCountRequest[]>;
+}

--- a/src/domain/sectors/sectors.interfaces.ts
+++ b/src/domain/sectors/sectors.interfaces.ts
@@ -1,0 +1,15 @@
+export interface SectorNameRequest {
+  id: number;
+  name: string;
+}
+
+export interface SectorCountRequest {
+  id: number;
+  count: number;
+}
+
+export interface SectorRequest {
+  id: number;
+  count?: number | undefined;
+  name: string;
+}

--- a/src/graphql/client/schema.graphql
+++ b/src/graphql/client/schema.graphql
@@ -103,7 +103,7 @@ type Query {
     brandId: String!
   ): [ChannelPerformanceMetrics!]
 
-  """
+  """ 
   List Folders and creatives from specific folder
   """
   listFolder(input: CreativeLibraryFilter!): CreativeLibraryFolder!


### PR DESCRIPTION
## Add “Creatives” table in Library page

#### Features implemented

- [X]  Creatives are displayed in a table.
- [X]  Each row must show a thumbnail, name, upload date and a file type.
- [X]  Each brand has creativities (you can test it changing the brand in the top navbar selector)

#### Description

Implemented `listFolder` back-end call to fetch folders for current brand. It can be accessed using the `useCurrentBrandCreatives` custom react hook. This is dynamic and will change instantly when changing selected brand. For access to not logged in brand's creatives, use `listFolder` call from  `useCreativesFeature`.

## Add a new “Sectors” page

#### Features implemented

- [X]  We want to see them in a responsive grid (numbers of rows changes on window resize)
- [X]  Each sector show the name and the number of businesses in each of them (count).
- [X]  We want to simulate that the request is real showing a spinner for a few moments.

#### Description

Implemented `getSectorsName` and `getSectorsCount` back-end calls to fetch sectors data. This is **hardcodded** since the back-end implementation is missing. It can be accessed using the `useSectors` custom react hook. The data response is a merged object of both `getSectorsName` and `getSectorsCount` calls.